### PR TITLE
Add optional fetcher argument to generate_feed_urls

### DIFF
--- a/feed_seeker/feed_seeker.py
+++ b/feed_seeker/feed_seeker.py
@@ -235,7 +235,7 @@ class FeedSeeker(object):
             yield self.url, seen
             return
 
-        myclass = type(self)
+        cls = type(self)        # get object class (in case subclassed)
 
         for url_fn in (self.find_link_feeds, self.find_anchor_feeds, self.guess_feed_links):
             for url in url_fn():
@@ -243,14 +243,14 @@ class FeedSeeker(object):
                     seen.add(url)
                     if not self._should_continue(seen, max_links):
                         return
-                    if myclass(url, html=None, fetcher=self.fetcher).is_feed():
+                    if cls(url, html=None, fetcher=self.fetcher).is_feed():
                         yield url, seen
 
         if spider > 0:
             for internal_link in self.find_internal_links():
-                print("Internal Link: {}".format(internal_link))
+                #print("Internal Link: {}".format(internal_link))
                 #sys.exit()
-                spider_seeker = myclass(internal_link, html=None, fetcher=self.fetcher)
+                spider_seeker = cls(internal_link, html=None, fetcher=self.fetcher)
                 kwargs = {
                     'spider': spider - 1,
                     'seen': seen,

--- a/setup.py
+++ b/setup.py
@@ -15,12 +15,12 @@ with open(requirements_file) as f:
 
 setup(
     name='feed_seeker',
-    version='1.0.0',
-    description='Extract rss, atom, and other feeds from webpages',
+    version='1.1.0',
+    description='Find rss, atom, xml, and rdf feeds on webpages',
     long_description=long_description,
     author='Colin Carroll',
     author_email='ccarroll@mit.edu',
-    url='https://github.com/mitmedialab/feed_seeker',
+    url='https://github.com/mediacloud/feed_seeker',
     license='MIT',
     classifiers=[
         'Development Status :: 3 - Alpha',
@@ -29,6 +29,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.10',
     ],
     packages=find_packages(exclude=['test']),
     python_requires='>=3.5',


### PR DESCRIPTION
This will allow web-search to supply a fetcher function that uses custom requests Session object

Also:
* Add tests for new FeedFetcher fetcher argument
* Pass self.fetcher when recursively creating FeedFetcher objects
* Use type(self) for recursive creation, to better allow subclassing
* Comment out a debug print
* Updated setup.py:
    + version to 1.1
    +  url to mediacloud (but did not change author)
    + changed "Extract" in short description to "Find" (which is used in long description/README file)

