### PR TITLE
Fix deprecated `publicsuffix` and beautifulsoup kwarg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .coverage
 htmlcov/
 *.egg-info/
+__pycache__/

--- a/feed_seeker/feed_seeker.py
+++ b/feed_seeker/feed_seeker.py
@@ -12,7 +12,7 @@ import sys
 from requests.adapters import HTTPAdapter
 from requests.exceptions import InvalidSchema, RetryError
 from urllib3.util.retry import Retry
-import publicsuffix
+import publicsuffix2
 import time
 
 @contextmanager
@@ -382,8 +382,8 @@ class FeedSeeker(object):
         search_url = "https://cloud.feedly.com/v3/search/feeds"
 
         # Fetch current public suffix list and determine root domain of url
-        psl = publicsuffix.fetch()
-        ps = publicsuffix.PublicSuffixList(psl)
+        psl = publicsuffix2.fetch()
+        ps = publicsuffix2.PublicSuffixList(psl)
         self.uri_root_domain = ps.get_public_suffix(self.url)
         self.uri_hostname = urlparse(self.url).hostname
         self.uri_domain_only = self.uri_root_domain.split('.', 1)[0]

--- a/feed_seeker/feed_seeker.py
+++ b/feed_seeker/feed_seeker.py
@@ -159,7 +159,7 @@ class FeedSeeker(object):
     def soup(self):
         """BeautifulSoup representation of the data."""
         if self._soup is None:
-            self._soup = BeautifulSoup(self.html, 'lxml')
+            self._soup = BeautifulSoup(self.html, features='lxml-xml')
         return self._soup
 
     def clean_url(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "beautifulsoup4>=4.6.0",
     "lxml>=4.1.1",
     "requests>=2.18.4",
-    "publicsuffix>=1.1.0",
+    "publicsuffix2>=2.20191221",
     "urllib3>=1.24.1",
     "pytest==4.5.0",
     "responses>=0.10.6",

--- a/test/test_feed_finder.py
+++ b/test/test_feed_finder.py
@@ -42,6 +42,20 @@ def test_find_feed_max_time():
     feed_seeker.find_feed_url(url, max_time=max_time)
 
 
+def test_feeedly_feeds():
+    url = 'https://www.nytimes.com'
+    feeds_gen = feed_seeker.find_feedly_feeds(url)
+    feeds_list = list(feeds_gen)
+    some_expected_feeds = [
+        'http://www.nytimes.com/services/xml/rss/nyt/HomePage.xml',
+        'http://www.nytimes.com/services/xml/rss/nyt/World.xml',
+        'http://www.nytimes.com/services/xml/rss/nyt/US.xml',
+        'http://www.nytimes.com/services/xml/rss/nyt/Sports.xml',
+    ]
+    for feed in some_expected_feeds:
+        assert feed in feeds_list
+
+
 @responses.activate
 def test_generate_feeds_max_time():
     max_time = 0.5


### PR DESCRIPTION
Hi! As I was preparing to work on #14, I noticed two minor issues. I describe them a bit more below.

Thanks!

**Update from `publicsuffix` to `publicsuffix2`**

According to its [PyPI page](https://pypi.org/project/publicsuffix/), `publicsuffix` is deprecated. It also caused a warning about something in setuptools. `publicsuffix2` seems to share the same API, some of the same authors, and does not cause a warning from what I could tell.

**XML in beautifulsoup**

Beautifulsoup was issuing the warning below about parsing xml as html. Changing `lxml` for `lxml-xml` fixed the issue.

```python
  /home/vandal/repos/perso/feed_seeker/feed_seeker/feed_seeker.py:162: XMLParsedAsHTMLWarning: It looks like you're using an HTML parser to parse an XML document.

  Assuming this really is an XML document, what you're doing might work, but you should know that using an XML parser will be more reliable. To parse this document as XML, make sure you have the Python package 'lxml' installed, and pass the keyword argument `features="xml"` into the BeautifulSoup constructor.

  If you want or need to use an HTML parser on this document, you can make this warning go away by filtering it. To do that, run this code before calling the BeautifulSoup constructor:

      from bs4 import XMLParsedAsHTMLWarning
      import warnings

      warnings.filterwarnings("ignore", category=XMLParsedAsHTMLWarning)

    self._soup = BeautifulSoup(self.html, 'lxml')
```