### PR TITLE
Add a command-line interface

### DIFF
--- a/feed_seeker/__main__.py
+++ b/feed_seeker/__main__.py
@@ -1,6 +1,9 @@
 import sys
 from argparse import ArgumentParser
-from feed_seeker import find_feed_url, generate_feed_urls, find_feedly_feeds
+
+from feed_seeker import find_feed_url, find_feedly_feeds, generate_feed_urls
+
+# TODO: Used for tests, remove
 # https://ici.radio-canada.ca/rss
 
 
@@ -26,19 +29,46 @@ def main():
     psr.add_argument(
         "--max-links", help="Maximum links to check as feeds.", type=int, default=None
     )
-    psr.add_argument("--all", help="Find all feeds under the provided URL", action="store_true")
-    psr.add_argument("--feedly", help="Find all feeds under the provided URL using Feedly, takes precedence over '--all'", action="store_true")
+    psr.add_argument(
+        "--all", help="Find all feeds under the provided URL", action="store_true"
+    )
+    psr.add_argument(
+        "--feedly",
+        help="Find all feeds under the provided URL using Feedly, takes precedence over '--all'",
+        action="store_true",
+    )
     args = psr.parse_args()
 
+    defaults = {action.dest: action.default for action in psr._actions}
 
     feed_urls = []
-    # TODO: Handle args that are not used by feedly
     if args.feedly:
+        feedly_ignored_args = ["html", "spider", "max-time", "all"]
+        for arg_name in feedly_ignored_args:
+            py_arg_name = arg_name.replace("-", "_")
+            default_val = defaults[py_arg_name]
+            current_val = getattr(args, py_arg_name)
+            if default_val != current_val:
+                print(f"--{arg_name} is ignored when --feedly is used", file=sys.stderr)
         feed_urls += list(find_feedly_feeds(args.url, max_links=args.max_links))
     elif args.all:
-        feed_urls += list(generate_feed_urls(args.url, htø=args.html, spider=args.spider, max_time=args.max_time, max_links=args.max_links))
+        feed_urls += list(
+            generate_feed_urls(
+                args.url,
+                html=args.html,
+                spider=args.spider,
+                max_time=args.max_time,
+                max_links=args.max_links,
+            )
+        )
     else:
-        feed_url = find_feed_url(args.url, html=args.html, spider=args.spider, max_time=args.max_time, max_links=args.max_links)
+        feed_url = find_feed_url(
+            args.url,
+            html=args.html,
+            spider=args.spider,
+            max_time=args.max_time,
+            max_links=args.max_links,
+        )
         if feed_url is not None:
             feed_urls.append(feed_url)
 

--- a/feed_seeker/__main__.py
+++ b/feed_seeker/__main__.py
@@ -1,0 +1,54 @@
+import sys
+from argparse import ArgumentParser
+from feed_seeker import find_feed_url, generate_feed_urls, find_feedly_feeds
+# https://ici.radio-canada.ca/rss
+
+
+def main():
+    # TODO: Write tests for the CLI
+    psr = ArgumentParser(
+        prog="feed_seeker", description="Find the most likely feed URL for a webpage"
+    )
+    psr.add_argument("url", help="URL of the webpage to search from")
+    psr.add_argument("--html", help="Optional raw HTML t save a second web fetch")
+    psr.add_argument(
+        "--spider",
+        help="How many times to restart the seeker on links with the same hostname on this page",
+        type=int,
+        default=0,
+    )
+    psr.add_argument(
+        "--max-time",
+        help="Max time allowed for a request to return something",
+        default=None,
+        type=float,
+    )
+    psr.add_argument(
+        "--max-links", help="Maximum links to check as feeds.", type=int, default=None
+    )
+    psr.add_argument("--all", help="Find all feeds under the provided URL", action="store_true")
+    psr.add_argument("--feedly", help="Find all feeds under the provided URL using Feedly, takes precedence over '--all'", action="store_true")
+    args = psr.parse_args()
+
+
+    feed_urls = []
+    # TODO: Handle args that are not used by feedly
+    if args.feedly:
+        feed_urls += list(find_feedly_feeds(args.url, max_links=args.max_links))
+    elif args.all:
+        feed_urls += list(generate_feed_urls(args.url, htø=args.html, spider=args.spider, max_time=args.max_time, max_links=args.max_links))
+    else:
+        feed_url = find_feed_url(args.url, html=args.html, spider=args.spider, max_time=args.max_time, max_links=args.max_links)
+        if feed_url is not None:
+            feed_urls.append(feed_url)
+
+    if len(feed_urls) == 0:
+        print("No feed found", file=sys.stderr)
+        sys.exit(1)
+
+    for feed_url in feed_urls:
+        print(feed_url)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,5 +36,9 @@ test = [
     "pytest", "pytest-cov"
 ]
 
+[project.scripts]
+feedseeker = "feed_seeker.__main__:main"
+
+
 [project.urls]
 "Homepage" = "https://mediacloud.org"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "requests>=2.18.4",
     "publicsuffix>=1.1.0",
     "urllib3>=1.24.1",
-    "pytest==4.5.0",
+    "pytest>=4.5.0",
     "responses>=0.10.6",
     "typing>=3.6.6"
 ]

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -1,0 +1,113 @@
+import sys
+from urllib.parse import urlparse
+
+import pytest
+
+from feed_seeker.__main__ import main
+
+
+@pytest.fixture
+def run_main(monkeypatch, capsys):
+    """Fixture to run main with arguments and return output."""
+
+    def _run(*args):
+        monkeypatch.setattr(sys, "argv", ["feedseeker"] + list(args))
+        try:
+            main()
+            exit_code = 0
+        except SystemExit as e:
+            exit_code = e.code
+
+        captured = capsys.readouterr()
+        return captured.out, captured.err, exit_code
+
+    return _run
+
+
+def get_domain(url):
+    """Extract domain with scheme from URL."""
+    return f"https://{urlparse(url).netloc}"
+
+
+def parse_output_lines(output):
+    """Split output into non-empty lines."""
+    return [line for line in output.splitlines() if line.strip()]
+
+
+def test_main_single(run_main):
+    url = "https://ici.radio-canada.ca/rss"
+    domain = get_domain(url)
+
+    stdout, stderr, exit_code = run_main(url)
+
+    assert stdout.startswith(domain)
+    assert stderr == ""
+    assert exit_code == 0
+
+
+def test_main_all(run_main):
+    url = "https://ici.radio-canada.ca/rss"
+    domain = get_domain(url)
+    max_links = 10
+
+    stdout, stderr, exit_code = run_main(url, "--all", "--max-links", str(max_links))
+
+    links = parse_output_lines(stdout)
+    assert len(links) <= max_links
+    for link in links:
+        assert link.startswith(domain)
+    assert stderr == ""
+    assert exit_code == 0
+
+
+def test_main_feedly(run_main):
+    url = "https://ici.radio-canada.ca/rss"
+    domain = get_domain(url)
+
+    stdout, stderr, exit_code = run_main(url, "--feedly")
+
+    links = parse_output_lines(stdout)
+    assert len(links) > 0
+    for link in links:
+        assert link.startswith(domain)
+    assert stderr == ""
+    assert exit_code == 0
+
+
+def test_feedly_unsupported(run_main):
+    url = "https://ici.radio-canada.ca/rss"
+    domain = get_domain(url)
+    unsupported_args = {
+        "html": "afile.html",
+        "spider": 1,
+        "max-time": 10,
+        "all": "",
+        "max-links": 10,
+    }
+    args = [url, "--feedly"]
+    for argname, argval in unsupported_args.items():
+        args.append(f"--{argname}")
+        if argval != "":
+            args.append(str(argval))
+
+    stdout, stderr, exit_code = run_main(*args)
+
+    links = parse_output_lines(stdout)
+    assert len(links) > 0
+    for link in links:
+        assert link.startswith(domain)
+    for arg in unsupported_args:
+        assert arg in stderr
+    assert exit_code == 0
+
+
+def test_no_feed(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["feedseeker", "https://hatch.pypa.io/latest/"])
+
+    with pytest.raises(SystemExit) as e:
+        main()
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == "No feed found\n"
+    assert e.value.code == 1


### PR DESCRIPTION
This fixes #14 and adds a CLI to `feed_seeker`. It is implemented in the `__main__py` module and set as the `feedseeker` script in `pyproject.toml`. That way it can be accessed through `python -m feed_seeker` or through `feedseeker`. I found `feedseeker` better suited for a CLI than `feed_seeker` with an underscore, but that can be changed easily if you prefer the underscore.

I also added a few unit tests for the CLI.

Thank you!